### PR TITLE
Use non-capturing groups for incidental grouping

### DIFF
--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -9,7 +9,7 @@
                        [:* [:not \\.]]
                        [:alt \"com\" \"org\" \"net\"]
                        :end])
-     \"\\\\A[a-zA-Z0-9_-]\\\\Q@\\\\E[0-9]{3,5}([^.]*)(\\\\Qcom\\\\E|\\\\Qorg\\\\E|\\\\Qnet\\\\E)\\\\Z\" "
+     \"\\\\A[a-zA-Z0-9_-]\\\\Q@\\\\E[0-9]{3,5}(?:[^.]*)(?:\\\\Qcom\\\\E|\\\\Qorg\\\\E|\\\\Qnet\\\\E)\\\\z\" "
   #?(:clj (:import java.util.regex.Pattern)))
 
 ;; - Do we need escaping inside [:class]? caret/dash?
@@ -111,7 +111,7 @@
     (let [s (apply str (map grouped->str* g))]
       (if (::grouped (meta g))
         s
-        (str "(" s ")")))
+        (str "(?:" s ")")))
 
     :else
     (assert false g)))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -47,4 +47,8 @@
   (is (= #?(:clj "\\A\\Qa\\E\\z"
             :cljs "^a$")
          (reg-str (regal/regex [:cat :start \a :end]))))
+
+  (is (= #?(:clj "\\Qa\\E(?:\\Qb\\E|\\Qc\\E)"
+            :cljs "a(?:b|c)")
+         (reg-str (regal/regex [:cat "a" [:alt "b" "c"]]))))
   )


### PR DESCRIPTION
Hi,

thanks for starting this effort! Ever since I've moved from CHICKEN to Clojure (for the most part), I've been missing [Irregex](http://synthcode.com/scheme/irregex/) so I hope for regal to finally fill this gap now :raised_hands: Here's my first humble contribution.

Moritz

---

This is in preparation of introducing explicit capturing
groups. However, it turns out that this is desirable on its own
because using capturing groups for incidental grouping purposes as
regal does right now has an effect on the result of `re-find` and
friends:

    (re-find #"a(b|c)" "ab")   => ["ab" "b"]
    (re-find #"a(?:b|c)" "ab") => "ab"

So users whould have had to figure out whether a regal expression
would compile to such incidental groups to reliably handle match
results.