### PR TITLE
Make kaocha launcher more portable and reliable

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 [[ -d node_modules ]] || npm install ws
 


### PR DESCRIPTION
Just a small improvement. Makes it work on NixOS, for example, where there is no `/bin/bash`.