### PR TITLE
Capturing groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If you find value in our work please consider [becoming a backer on Open Collect
   - `[:class entries...]` : match any of the given characters or ranges, with ranges given as two element vectors. E.g. `[:class [\a \z] [\A \Z] "_" "-"]` is equivalent to `[a-zA-Z_-]`
   - `[:not entries...]` : like `:class`, but negates the result, equivalent to `[^...]`
   - `[:repeat form min max]` : repeat a form a number of times, like `{2,5}`
+  - `[:capture forms...]` : capturing group with implicit concatenation of the given forms
 
 ### BYO test.check
 

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -9,7 +9,7 @@
                        [:* [:not \\.]]
                        [:alt \"com\" \"org\" \"net\"]
                        :end])
-     \"\\\\A[a-zA-Z0-9_-]\\\\Q@\\\\E[0-9]{3,5}([^.]*)(\\\\Qcom\\\\E|\\\\Qorg\\\\E|\\\\Qnet\\\\E)\\\\Z\" "
+     \"\\\\A[a-zA-Z0-9_-]\\\\Q@\\\\E[0-9]{3,5}(?:[^.]*)(?:\\\\Qcom\\\\E|\\\\Qorg\\\\E|\\\\Qnet\\\\E)\\\\z\" "
   #?(:clj (:import java.util.regex.Pattern)))
 
 ;; - Do we need escaping inside [:class]? caret/dash?
@@ -111,7 +111,7 @@
     (let [s (apply str (map grouped->str* g))]
       (if (::grouped (meta g))
         s
-        (str "(" s ")")))
+        (str "(?:" s ")")))
 
     :else
     (assert false g)))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -47,4 +47,8 @@
   (is (= #?(:clj "\\A\\Qa\\E\\z"
             :cljs "^a$")
          (reg-str (regal/regex [:cat :start \a :end]))))
+
+  (is (= #?(:clj "\\Qa\\E(?:\\Qb\\E|\\Qc\\E)"
+            :cljs "a(?:b|c)")
+         (reg-str (regal/regex [:cat "a" [:alt "b" "c"]]))))
   )

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -51,4 +51,12 @@
   (is (= #?(:clj "\\Qa\\E(?:\\Qb\\E|\\Qc\\E)"
             :cljs "a(?:b|c)")
          (reg-str (regal/regex [:cat "a" [:alt "b" "c"]]))))
+
+  (is (= #?(:clj "(\\Qabc\\E)"
+            :cljs "(abc)")
+         (reg-str (regal/regex [:capture "abc"]))))
+
+  (is (= #?(:clj "\\Qa\\E(\\Qb\\E|\\Qc\\E)"
+            :cljs "a(b|c)")
+         (reg-str (regal/regex [:cat "a" [:capture [:alt "b" "c"]]]))))
   )


### PR DESCRIPTION
This branch builds on PR #4. I've decided to submit them separately because this one here might require some discussion on how to introduce capturing groups. I propose a new form `[:capture forms...]`. I've left out backreferences and named capturing groups for now as basic capturing groups are pretty useful on their own already.

See the commit message of 758dd18 for rationale for some of the changes.