### PR TITLE
Reimplement regex compilation based on spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you find value in our work please consider [becoming a backer on Open Collect
 
 ;; Convert to host-specific regex
 (regal/regex r)
-;;=> #"(?:[a-z]+)\Q=\E(?:[^=]+)"
+;;=> #"[a-z]+\Q=\E[^=]+"
 
 ;; Match strings
 (re-matches (regal/regex r) "foo=bar")

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -44,6 +44,10 @@
             :cljs  "a{3,5}")
          (reg-str (regal/regex [:repeat \a 3 5]))))
 
+  (is (= #?(:clj "(?:\\Qfoo\\E){3,5}"
+            :cljs  "(?:foo){3,5}")
+         (reg-str (regal/regex [:repeat "foo" 3 5]))))
+
   (is (= #?(:clj "\\A\\Qa\\E\\z"
             :cljs "^a$")
          (reg-str (regal/regex [:cat :start \a :end]))))


### PR DESCRIPTION
Allows validation of regal forms and improves extensibility.

Redundant groupings are now avoided in more cases.

Also fixes a bug where quantifiers on multi-character string literals
would be compiled to only apply to the last character (see
corresponding regression test).

Oh yeah, and I've decided to rename `tokens` to `aliases`, the idea being that this could turn into a registry where users could register their own aliases for any regal expression (by qualified key).

Hope it all makes sense!