### PR TITLE
Fix quantifiers on multi-character strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you find value in our work please consider [becoming a backer on Open Collect
 
 ;; Convert to host-specific regex
 (regal/regex r)
-;;=> #"(?:[a-z]+)\Q=\E(?:[^=]+)"
+;;=> #"[a-z]+\Q=\E[^=]+"
 
 ;; Match strings
 (re-matches (regal/regex r) "foo=bar")

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -9,7 +9,7 @@
                  [:* [:not \\.]]
                  [:alt \"com\" \"org\" \"net\"]
                  :end])
-     #\"\\A[a-zA-Z0-9_-]\\Q@\\E[0-9]{3,5}(?:[^.]*)(?:\\Qcom\\E|\\Qorg\\E|\\Qnet\\E)\\z\" "
+     #\"\\A[a-zA-Z0-9_-]\\Q@\\E[0-9]{3,5}[^.]*(?:\\Qcom\\E|\\Qorg\\E|\\Qnet\\E)\\z\" "
   #?(:clj (:import java.util.regex.Pattern)))
 
 ;; - Do we need escaping inside [:class]? caret/dash?
@@ -54,7 +54,7 @@
                      (> (count (str (first rs))) 1))
               (list rsg)
               rsg)]
-    (list rsg q)))
+    `^::grouped (~rsg ~q)))
 
 (defmethod -regal->grouped :* [[_ r]]
   (quantifier->grouped \* [r]))

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -44,14 +44,29 @@
 (defmethod -regal->grouped :alt [[_ & rs]]
   (interpose \| (map regal->grouped rs)))
 
+(defn quantifier->grouped [q rs]
+  (let [rsg (regal->grouped (into [:cat] rs))
+        ;; This forces explicit grouping for multi-character string
+        ;; literals so that e.g. [:* "ab"] compiles to #"(?:ab)*"
+        ;; rather than #"ab*".
+        rsg (if (and (string? rsg)
+                     (not (next rs))
+                     (> (count (str (first rs))) 1))
+              (list rsg)
+              rsg)]
+    (list rsg q)))
+
 (defmethod -regal->grouped :* [[_ r]]
-  (list (regal->grouped r) \*))
+  (quantifier->grouped \* [r]))
 
 (defmethod -regal->grouped :+ [[_ r]]
-  (list (regal->grouped r) \+))
+  (quantifier->grouped \+ [r]))
 
 (defmethod -regal->grouped :? [[_ & rs]]
-  (list (regal->grouped (into [:cat] rs)) \?))
+  (quantifier->grouped \? rs))
+
+(defmethod -regal->grouped :repeat [[_ r & ns]]
+  (quantifier->grouped `^::grouped (\{ ~@(interpose \, (map str ns)) \}) [r]))
 
 (defmethod -regal->grouped :range [[_ from to]]
   `^::grouped (\[ ~from \- ~to \]))
@@ -75,9 +90,6 @@
 
 (defmethod -regal->grouped :not [[_ & cs]]
   `^::grouped (\[ \^ ~@(compile-class cs) \]))
-
-(defmethod -regal->grouped :repeat [[_ r & ns]]
-  `^::grouped (~(regal->grouped r) \{ ~@(interpose \, (map str ns)) \} ))
 
 (defmethod -regal->grouped :capture [[_ & rs]]
   `^::grouped (\( ~@(regal->grouped (into [:cat] rs)) \)))

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -56,11 +56,11 @@
               rsg)]
     `^::grouped (~rsg ~q)))
 
-(defmethod -regal->grouped :* [[_ r]]
-  (quantifier->grouped \* [r]))
+(defmethod -regal->grouped :* [[_ & rs]]
+  (quantifier->grouped \* rs))
 
-(defmethod -regal->grouped :+ [[_ r]]
-  (quantifier->grouped \+ [r]))
+(defmethod -regal->grouped :+ [[_ & rs]]
+  (quantifier->grouped \+ rs))
 
 (defmethod -regal->grouped :? [[_ & rs]]
   (quantifier->grouped \? rs))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -27,6 +27,10 @@
             :cljs "(?:ab)*")
          (reg-str (regal/regex [:* "ab"]))))
 
+  (is (= #?(:clj "(?:\\Qa\\E\\Qb\\E)*"
+            :cljs "(?:ab)*")
+         (reg-str (regal/regex [:* "a" "b"]))))
+
   (is (= #?(:clj "(?:\\Qa\\E|\\Qb\\E)*"
             :cljs "(?:a|b)*")
          (reg-str (regal/regex [:* [:alt "a" "b"]]))))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -23,6 +23,14 @@
             :cljs "a*")
          (reg-str (regal/regex [:* "a"]))))
 
+  (is (= #?(:clj "(?:\\Qab\\E)*"
+            :cljs "(?:ab)*")
+         (reg-str (regal/regex [:* "ab"]))))
+
+  (is (= #?(:clj "(?:\\Qa\\E|\\Qb\\E)*"
+            :cljs "(?:a|b)*")
+         (reg-str (regal/regex [:* [:alt "a" "b"]]))))
+
   (is (= #?(:clj "\\Qa\\E+"
             :cljs "a+")
          (reg-str (regal/regex [:+ "a"]))))


### PR DESCRIPTION
This branch backports the bug fix from https://github.com/lambdaisland/regal/pull/8 onto master. Also included are two more changes from that PR I considered worthwhile. Since they also affect quantifiers, I figured I might as well include them here. 

Note that I reversed my stance on considering quantifier expressions as grouped once more :-) While it does indeed compile to invalid regex in cases like `[:* [:* \x]]`, such an expression is pretty nonsensical to begin with, so why try to support it. The readability win for the resulting regex trumps that disadvantage IMHO but feel free to disagree.