### PR TITLE
Add spec alpha definitions for regal expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you find value in our work please consider [becoming a backer on Open Collect
   - `[:not entries...]` : like `:class`, but negates the result, equivalent to `[^...]`
   - `[:repeat form min max]` : repeat a form a number of times, like `{2,5}`
   - `[:capture forms...]` : capturing group with implicit concatenation of the given forms
+- A `clojure.spec.alpha` definition of the grammar can be made available as `:lambdaisland.regal/form` by explicitly requiring `lambdaisland.regal.spec-alpha`
 
 ### BYO test.check
 

--- a/src/lambdaisland/regal/spec_alpha.clj
+++ b/src/lambdaisland/regal/spec_alpha.clj
@@ -1,7 +1,7 @@
 (ns lambdaisland.regal.spec-alpha
   (:require [lambdaisland.regal :as regal]
             [clojure.spec.alpha :as s]
-            [clojure.test.check.generators :as gen]))
+            [clojure.spec.gen.alpha :as gen]))
 
 (s/fdef regal/regex :args (s/cat :form ::regal/form))
 

--- a/src/lambdaisland/regal/spec_alpha.clj
+++ b/src/lambdaisland/regal/spec_alpha.clj
@@ -1,0 +1,73 @@
+(ns lambdaisland.regal.spec-alpha
+  (:require [lambdaisland.regal :as regal]
+            [clojure.spec.alpha :as s]))
+
+(s/fdef regal/regex :args (s/cat :form ::regal/form))
+
+(s/def ::regal/form
+  (s/or :literal ::regal/literal
+        :token   ::regal/token
+        :op      ::regal/op))
+
+(s/def ::regal/literal
+  (s/or :string string?
+        :char   char?))
+
+(s/def ::regal/token simple-keyword?)
+
+(defmulti op first)
+
+(s/def ::regal/op
+  (s/and vector?
+         (s/multi-spec op (fn [v t] (cons t v)))))
+
+(defn op-spec [args-spec]
+  (s/cat :op keyword?
+         :args args-spec))
+
+(defmethod op :cat [_]
+  (op-spec (s/* ::regal/form)))
+
+(defmethod op :alt [_]
+  (op-spec (s/* ::regal/form)))
+
+(defmethod op :capture [_]
+  (op-spec (s/* ::regal/form)))
+
+(defmethod op :* [_]
+  (op-spec (s/+ ::regal/form)))
+
+(defmethod op :+ [_]
+  (op-spec (s/+ ::regal/form)))
+
+(defmethod op :? [_]
+  (op-spec (s/+ ::regal/form)))
+
+(s/def ::regal/repeat-min nat-int?)
+(s/def ::regal/repeat-max nat-int?)
+
+(defmethod op :repeat [_]
+  (op-spec (s/cat :form ::regal/form
+                  :min  ::regal/repeat-min
+                  :min  (s/? ::regal/repeat-max))))
+
+(s/def ::regal/range-start char?)
+(s/def ::regal/range-end char?)
+
+(s/def ::regal/range
+  (s/cat :start ::regal/range-start
+         :end   ::regal/range-end))
+
+(defmethod op :range [_]
+  (op-spec ::regal/range))
+
+(s/def ::regal/class
+  (s/+ (s/or :range ::regal/range
+             :char   char?
+             :string string?)))
+
+(defmethod op :class [_]
+  (op-spec ::regal/class))
+
+(defmethod op :not [_]
+  (op-spec ::regal/class))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -1,6 +1,10 @@
 (ns lambdaisland.regal-test
   (:require [lambdaisland.regal :as regal]
+            lambdaisland.regal.spec-alpha
+            [clojure.spec.test.alpha :as stest]
             [clojure.test :refer [deftest testing is are]]))
+
+(stest/instrument `regal/regex)
 
 (defn reg-str
   "Regex to string, remove the slashes that JavaScript likes to add."


### PR DESCRIPTION
Can be made available by explicitly requiring
`lambdaisland.regal.spec-alpha`.

Tests now use those specs and instrument `regal/regex` to hopefully
catch divergence of spec and implementation.

As discussed in https://github.com/lambdaisland/regal/pull/8