### PR TITLE
Experiment with both generating Regal expressions, and parsing regex

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,5 @@
-((nil . ((cider-clojure-cli-global-options . "-A:dev:test:cljs:test-check"))))
+((nil . ((cider-clojure-cli-global-options . "-A:dev:test:cljs:test-check:test-chuck")))
+ (clojure . ((eval . (define-clojure-indent
+                       (assoc 0)
+                       (for-all 1)
+                       (ex-info 0))))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
-((nil . ((cider-clojure-cli-global-options . "-A:dev:test:cljs:test-check:test-chuck")))
+((nil . ((cider-clojure-cli-global-options . "-A:dev:test:cljs:spec-alpha:test-check:instaparse")
+         (cider-default-cljs-repl . node)))
  (clojure . ((eval . (define-clojure-indent
                        (assoc 0)
                        (for-all 1)

--- a/README.md
+++ b/README.md
@@ -69,14 +69,46 @@ If you find value in our work please consider [becoming a backer on Open Collect
   - `[:capture forms...]` : capturing group with implicit concatenation of the given forms
 - A `clojure.spec.alpha` definition of the grammar can be made available as `:lambdaisland.regal/form` by explicitly requiring `lambdaisland.regal.spec-alpha`
 
-### BYO test.check
+### Use with spec.alpha
 
-Regal does not declare a dependency on `org.clojure/test.check`. If you want to
-use the generators, you need to include this dependency yourself.
+``` clojure
+(require '[lambdaisland.regal.spec-alpha :as regal-spec]
+         '[clojure.spec.alpha :as s]
+         '[clojure.spec.gen.alpha :as gen])
+
+(s/def ::x-then-y (regal-spec/spec [:cat [:+ "x"] "-" [:+ "y"]]))
+
+(s/def ::xy-with-stars (regal-spec/spec [:cat "*" ::x-then-y "*"]))
+
+(s/valid? ::xy-with-stars "*xxx-yy*")
+;; => true
+
+(gen/sample (s/gen ::xy-with-stars))
+;; => ("*x-y*"
+;;     "*xx-y*"
+;;     "*x-y*"
+;;     "*xxxx-y*"
+;;     "*xxx-yyyy*"
+;;     "*xxxx-yyy*"
+;;     "*xxxxxxx-yyyyy*"
+;;     "*xx-yyy*"
+;;     "*xxxxx-y*"
+;;     "*xxx-yyyy*")
+```
+
+### BYO test.check / spec-alpha
+
+Regal does not declare any dependencies. This lets people who only care about
+using Regal Expressions to replace normal regexes to require
+`lambdaisland.regal` without imposing extra dependencies upon them.
+
+If you want to use `lambdaisland.regal.generator` you will require
+`org.clojure/test.check`. For `lambdisland.regal.spec-alpha` you will
+additionally need `org.clojure/spec-alpha`.
 
 ### Contributing
 
-Everyone has a right to submit patches to this projects, and thus be a contributor.
+Everyone has a right to submit patches to this projects, and thus become a contributor.
 
 Contributors MUST
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ generating values that conform to the given pattern.
 Regal is Clojure and ClojureScript compatible, and glosses over some of the
 differences in Java and JavaScript regex syntax (like `\A` / `\z` vs `^` / `$`).
 
+<!-- opencollective -->
 ### Support Lambda Island Open Source
 
 If you find value in our work please consider [becoming a backer on Open Collective](http://opencollective.com/lambda-island#section-contribute)
+<!-- /opencollective -->
 
 ### An example
 
@@ -29,7 +31,7 @@ If you find value in our work please consider [becoming a backer on Open Collect
 
 ;; Regal expression, like Hiccup but for Regex
 (def r [:cat
-        [:+ [:range \a \z]]
+        [:+ [:class [\a \z]]]
         "="
         [:+ [:not \=]]])
 
@@ -62,7 +64,6 @@ If you find value in our work please consider [becoming a backer on Open Collect
   - `[:* form]` : match the given form zero or more times
   - `[:+ form]` : match the given form one or more times
   - `[:? form]` : match the given form zero or one time
-  - `[:range start end]` : match a range of characters, like `[a-z]`. Takes one-character strings or characters.
   - `[:class entries...]` : match any of the given characters or ranges, with ranges given as two element vectors. E.g. `[:class [\a \z] [\A \Z] "_" "-"]` is equivalent to `[a-zA-Z_-]`
   - `[:not entries...]` : like `:class`, but negates the result, equivalent to `[^...]`
   - `[:repeat form min max]` : repeat a form a number of times, like `{2,5}`
@@ -106,6 +107,7 @@ If you want to use `lambdaisland.regal.generator` you will require
 `org.clojure/test.check`. For `lambdisland.regal.spec-alpha` you will
 additionally need `org.clojure/spec-alpha`.
 
+<!-- contributing -->
 ### Contributing
 
 Everyone has a right to submit patches to this projects, and thus become a contributor.
@@ -136,6 +138,7 @@ feedback on it.
 `**` As long as this project has not seen a public release (i.e. is not on Clojars)
 we may still consider making breaking changes, if there is consensus that the
 changes are justified.
+<!-- /contributing -->
 
 ### Prior Art
 

--- a/README.md
+++ b/README.md
@@ -69,46 +69,14 @@ If you find value in our work please consider [becoming a backer on Open Collect
   - `[:capture forms...]` : capturing group with implicit concatenation of the given forms
 - A `clojure.spec.alpha` definition of the grammar can be made available as `:lambdaisland.regal/form` by explicitly requiring `lambdaisland.regal.spec-alpha`
 
-### Use with spec.alpha
+### BYO test.check
 
-``` clojure
-(require '[lambdaisland.regal.spec-alpha :as regal-spec]
-         '[clojure.spec.alpha :as s]
-         '[clojure.spec.gen.alpha :as gen])
-
-(s/def ::x-then-y (regal-spec/spec [:cat [:+ "x"] "-" [:+ "y"]]))
-
-(s/def ::xy-with-stars (regal-spec/spec [:cat "*" ::x-then-y "*"]))
-
-(s/valid? ::xy-with-stars "*xxx-yy*")
-;; => true
-
-(gen/sample (s/gen ::xy-with-stars))
-;; => ("*x-y*"
-;;     "*xx-y*"
-;;     "*x-y*"
-;;     "*xxxx-y*"
-;;     "*xxx-yyyy*"
-;;     "*xxxx-yyy*"
-;;     "*xxxxxxx-yyyyy*"
-;;     "*xx-yyy*"
-;;     "*xxxxx-y*"
-;;     "*xxx-yyyy*")
-```
-
-### BYO test.check / spec-alpha
-
-Regal does not declare any dependencies. This lets people who only care about
-using Regal Expressions to replace normal regexes to require
-`lambdaisland.regal` without imposing extra dependencies upon them.
-
-If you want to use `lambdaisland.regal.generator` you will require
-`org.clojure/test.check`. For `lambdisland.regal.spec-alpha` you will
-additionally need `org.clojure/spec-alpha`.
+Regal does not declare a dependency on `org.clojure/test.check`. If you want to
+use the generators, you need to include this dependency yourself.
 
 ### Contributing
 
-Everyone has a right to submit patches to this projects, and thus become a contributor.
+Everyone has a right to submit patches to this projects, and thus be a contributor.
 
 Contributors MUST
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,20 @@
 {:paths ["src" "test" "resources"]
- :deps  {org.clojure/clojure    {:mvn/version "1.10.1"}}
+ :deps  {org.clojure/clojure {:mvn/version "1.10.1"}}
 
  :aliases
  {:dev
   {}
 
+  :spec-alpha
+  {:extra-deps {org.clojure/spec.alpha {:mvn/version "0.2.176"}
+                expound                {:mvn/version "0.8.4"}}}
+
   :spec-alpha2
   {:extra-deps {org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
                                          :sha     "de38650874c6f0bc19e7755feab4d65b3fffb268"}}}
+
+  :instaparse
+  {:extra-deps {instaparse {:mvn/version "1.4.10"}}}
 
   :test-check
   {:extra-deps {org.clojure/test.check {:mvn/version "0.10.0"}}}
@@ -19,5 +26,5 @@
   {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.597"}}}
 
   :test
-  {:extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}
+  {:extra-deps {lambdaisland/kaocha      {:mvn/version "RELEASE"}
                 lambdaisland/kaocha-cljs {:mvn/version "RELEASE"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -5,8 +5,15 @@
  {:dev
   {}
 
+  :spec-alpha2
+  {:extra-deps {org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
+                                         :sha     "de38650874c6f0bc19e7755feab4d65b3fffb268"}}}
+
   :test-check
   {:extra-deps {org.clojure/test.check {:mvn/version "0.10.0"}}}
+
+  :test-chuck
+  {:extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}
 
   :cljs
   {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.597"}}}

--- a/repl_sessions/install_expound.cljc
+++ b/repl_sessions/install_expound.cljc
@@ -1,0 +1,5 @@
+(ns install-expound
+  (:require [clojure.spec.alpha :as s]
+            [expound.alpha :as expound]))
+
+(set! s/*explain-out* expound/printer)

--- a/repl_sessions/parse.cljc
+++ b/repl_sessions/parse.cljc
@@ -1,0 +1,43 @@
+(require '[lambdaisland.regal.spec-alpha :as regal-spec]
+         '[lambdaisland.regal :as regal]
+         '[clojure.test.check.generators]
+         '[clojure.spec.gen.alpha :as gen]
+         '[clojure.spec.alpha :as s])
+
+(->> "abc"
+     #_remove-QE
+     (instaparse/parse parser)
+     )
+
+(instaparse/transform
+ {:Regex (fn [r] r)
+  :Alternation (fn [& alts]
+                 (if (= (count alts) 1)
+                   (first alts)
+                   (into [:alt] (remove nil?) alts)))
+  :Concatenation (fn [& cats]
+                   (if (= (count cats) 1)
+                     (first cats)
+                     (into [:cat] (remove nil?) cats)))
+  :DanglingCurlyRepetitions (fn [& reps])
+  :SuffixedExpr (fn
+                  ([expr]
+                   expr)
+                  ([expr suffix]
+                   (throw (ex-info [:SuffixedExpr expr suffix]))))
+  :SingleExpr identity
+  :BaseExpr identity
+  :LiteralChar identity
+  :PlainChar identity}
+ (->> "ab\\x01"
+      #_remove-QE
+      (instaparse/parse parser)
+      )
+
+ )
+
+
+(run! regal/regex )
+(prn (s/gen :lambdaisland.regal/form))
+
+(regal/regex [:cat "abc"])

--- a/resources/lambdaisland/regal/regex.bnf
+++ b/resources/lambdaisland/regal/regex.bnf
@@ -1,0 +1,110 @@
+(** Original version by Gary Fredericks **)
+(** https://github.com/gfredericks/test.chuck/blob/57dc937f42dc5d4348ecc29782df5a5385d5e529/resources/com/gfredericks/test/chuck/regex.bnf **)
+(** Modified for lambdaisland/regal **)
+(** This file is licensed under the Eclipse Public License, version 1.0 **)
+
+Regex = Alternation
+
+Alternation = Concatenation (<'|'> Concatenation) *
+
+Concatenation = DanglingCurlyRepetitions (SuffixedExpr | <'('> MutatingMatchFlags <')'> DanglingCurlyRepetitions) *
+
+DanglingCurlyRepetitions = (CurlyRepetition Quantifier ?) *
+
+SuffixedExpr = SingleExpr Suffix ?
+SingleExpr = BaseExpr | ParenthesizedExpr
+ParenthesizedExpr = <'('> GroupFlags ? Alternation <')'>
+Suffix = (Optional | Positive | NonNegative | CurlyRepetition ) Quantifier ? DanglingCurlyRepetitions
+Optional = <'?'>
+Positive = <'+'>
+NonNegative = <'*'>
+CurlyRepetition = <'{'> #"\d+" (',' #"\d+" ?) ? <'}'>
+Quantifier = '?' | '+'
+BaseExpr = CharExpr | LiteralChar | LinebreakMatcher | Anchor | BackReference
+LinebreakMatcher = '\\R'
+Anchor = '^' | '$' | '\\' #"[bBAGZz]"
+LiteralChar = PlainChar | EscapedChar
+
+(* this will be hard -- will require counting in the analyzer to figure
+   out where the number stops and numberic literals begin *)
+BackReference = <'\\'> #"[1-9][0-9]*"
+
+PlainChar = #"[^.|\\+*$^\[(){?]"
+CharExpr = Dot | SpecialCharClass | UnicodeCharacterClass | BCC
+Dot = '.'
+
+(** BRACKETED CHARACTER CLASSES (AKA BCC) **)
+(** (which are more complicated than you thought they were) **)
+
+
+BCC = <'['> <'&&'> ? BCCIntersection <#"&{2,}"> ? <']'>
+BCCIntersection =  BCCUnionLeft (<#"&{2,}"> BCCUnionNonLeft ) *
+BCCUnionLeft = (BCCNegation BCCElemHardLeft | !'^' BCCElemHardLeft) BCCElemNonLeft *
+BCCUnionNonLeft = BCCElemLeft BCCElemNonLeft *
+BCCNegation = '^'
+
+(* The optional '&&' here cover some quirky NOOP edge cases *)
+BCCElemHardLeft = !'&&&' '&&' ? BCCElemBase | (']' ! ('-' BCCRangeRightable)) | BCCRangeWithBracket
+BCCElemLeft = BCCElemBase
+BCCElemNonLeft = BCCElemBase
+
+
+BCCElemBase = BCCCharNonRange | SpecialCharClass | UnicodeCharacterClass | BCCRange | BCC
+BCCRangeRightable = BCCCharEndRange | SpecialCharClass | UnicodeCharacterClass | '&'
+BCCRange = BCCChar <'-'> BCCCharEndRange
+BCCRangeWithBracket = <']-'> BCCCharEndRange
+BCCCharNonRange = BCCChar ! ('-' BCCRangeRightable)
+BCCChar = BCCPlainChar | EscapedChar | (BCCPlainAmpersand ! '&')
+BCCCharEndRange = BCCPlainChar | EscapedChar | BCCPlainAmpersand
+BCCPlainAmpersand = '&'
+BCCPlainChar = #"[^\]\[&\\]"
+(* only match an odd number of ampersands whatever *)
+(* This is problematic because re-pattern won't take repeated ampersands in the HardLeft position *)
+BCCDash = '-'
+
+
+(** BASE CHARACTER STUFFS **)
+
+EscapedChar = OctalChar | HexChar | BasicEscapedChar | NormalSlashedCharacters | ControlChar | NamedChar
+OctalChar = <'\\0'> (OctalDigits1 | OctalDigits2 | OctalDigits3)
+OctalDigits1 = #"[0-7]" ! #"[0-7]"
+OctalDigits2 = (#"[0-3][0-7]" ! #"[0-7]") | #"[4-7][0-7]"
+OctalDigits3 = #"[0-3][0-7]{2}"
+HexChar = ShortHexChar | MediumHexChar | LongHexChar
+ShortHexChar = <'\\x'> #'[0-9a-fA-F]{2}'
+MediumHexChar = <'\\u'> #'[0-9a-fA-F]{4}'
+LongHexChar = <'\\x{'> #'[0-9a-fA-F]+' <'}'>
+BasicEscapedChar = <'\\'> #"[^a-zA-Z0-9]"
+NamedChar = <'\\N{'> #'[-A-Z0-9\(\) ]+' <'}'>
+
+(* probably missing something here *)
+SpecialCharClass = <'\\'> #"[wWsSdDhHvVX]"
+(* Gotta figure out what these mean *)
+UnicodeCharacterClass = <'\\'> #'[pP]' (#"[CLMNPSZ]" | #"\{[a-zA-Z]+\}")
+
+NormalSlashedCharacters = #"\\[tnrfae]"
+
+(* why did I think you could have a backslashed character here?? *)
+ControlChar = <'\\c'> #"(?s)."
+
+(** FLAGS **)
+GroupFlags = NamedCapturingGroup
+           | NonCapturingMatchFlags
+           | PositiveLookAheadFlag
+           | NegativeLookAheadFlag
+           | PositiveLookBehindFlag
+           | NegativeLookBehindFlag
+           | IndependentNonCapturingFlag
+
+NamedCapturingGroup = <'?<'> GroupName <'>'>
+MutatingMatchFlags = <'?'> MatchFlagsExpr & ')'
+NonCapturingMatchFlags = <'?'> !')' MatchFlagsExpr <':'>
+PositiveLookAheadFlag = <'?='>
+NegativeLookAheadFlag = <'?!'>
+PositiveLookBehindFlag = <'?<='>
+NegativeLookBehindFlag = <'?<!'>
+IndependentNonCapturingFlag = <'?>'>
+(* the java 7 docs don't include 'c' here but openjdk accepts it for CANON_EQ *)
+MatchFlagsExpr = #"[idmsuxcU]" * ('-' #"[idmsuxcU]" *) ?
+
+GroupName = #"[a-zA-Z][a-zA-Z0-9]*"

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -5,7 +5,7 @@
                  :start
                  [:class [\\a \\z] [\\A \\Z] [\\0 \\9] \\_ \\-]
                  \"@\"
-                 [:repeat [:range \\0 \\9] 3 5]
+                 [:repeat [:class [\\0 \\9]] 3 5]
                  [:* [:not \\.]]
                  [:alt \"com\" \"org\" \"net\"]
                  :end])
@@ -48,7 +48,6 @@
 
 (declare regal->ir)
 
-(def -regal->ir nil)
 (defmulti -regal->ir (fn [[op] opts] op))
 
 (defmethod -regal->ir :cat [[_ & rs] opts]
@@ -81,9 +80,6 @@
 (defmethod -regal->ir :repeat [[_ r & ns] opts]
   (quantifier->ir `^::grouped (\{ ~@(interpose \, (map str ns)) \}) [r] opts))
 
-(defmethod -regal->ir :range [[_ from to] opts]
-  `^::grouped (\[ ~from \- ~to \]) opts)
-
 (defn- compile-class [cs]
   (reduce (fn [r c]
             (cond
@@ -94,7 +90,7 @@
               (conj r c)
 
               (vector? c)
-              (conj r (first c) "-" (second c))))
+              (conj r (first c) \- (second c))))
           []
           cs))
 
@@ -116,13 +112,13 @@
   contains naturally introduces some kind of grouping.
 
 
-      >>> (regal->ir \"hello\")
+      >>> (regal->ir \"hello\" {})
       \"\\Qhello\\E\"
 
-      >>> (regal->ir [:cat \"foo\" \"bar\"])
+      >>> (regal->ir [:cat \"foo\" \"bar\"] {})
       (\"\\Qfoo\\E\" \"\\Qbar\\E\")
 
-      >>> (regal->ir [:range \"a\" \"z\"])
+      >>> (regal->ir [:class [\"a\" \"z\"]] {})
       ^::grouped (\\[ \"a\" \\- \"z\" \\])"
   [r {:keys [resolver] :as opts}]
   (cond

--- a/src/lambdaisland/regal.cljc
+++ b/src/lambdaisland/regal.cljc
@@ -32,8 +32,13 @@
 (def ^:private tokens
   {:start #?(:clj "\\A" :cljs "^")
    :end #?(:clj "\\z" :cljs "$")
-   :any "."})
-
+   :any "."
+   :digit "\\d"
+   :non-digit "\\D"
+   :word "\\w"
+   :non-word "\\W"
+   :whitespace "\\s"
+   :non-whitespace "\\S"})
 
 ;; IR = Intermediate Representation
 ;;

--- a/src/lambdaisland/regal/generator.cljc
+++ b/src/lambdaisland/regal/generator.cljc
@@ -73,8 +73,35 @@
 
     (simple-keyword? r)
     (case r
-      :any gen/char
-      (gen/return ""))
+      :any
+      gen/char
+
+
+      :digit
+      (recur [:class [\0 \9]] opts)
+
+      :non-digit
+      (recur [:not [\0 \9]] opts)
+
+      :word
+      (recur [:class [\a \z] [\A \Z] [\0 \9] \_] opts)
+
+      :non-word
+      (recur [:not [\a \z] [\A \Z] [\0 \9] \_] opts)
+
+      :whitespace
+      (recur [:class \space \tab \newline \u000B \formfeed \return] opts)
+
+      :non-whitespace
+      (recur [:not \space \tab \newline \u000B \formfeed \return] opts)
+
+      :start
+      (gen/return "")
+
+      :end
+      (gen/return "")
+
+      (throw (ex-info (str "Unrecognized regal token: " r) {::unrecognized-token r})))
 
     :else
     (-generator r opts)))
@@ -118,10 +145,12 @@
   (gen/sample (gen r)))
 
 (comment
+  (sample [:cat :digit :whitespace :word])
+
   (let [pattern [:cat
                  :start
                  [:class [\a \z] [\A \Z] [\0 \9] \_ \-]
-                 "@"
+
                  [:capture
                   [:repeat [:class [\0 \9]] 3 5]
                   [:* [:not \.]]

--- a/src/lambdaisland/regal/generator.cljc
+++ b/src/lambdaisland/regal/generator.cljc
@@ -4,7 +4,6 @@
 
 (declare generator)
 
-(def -generator nil)
 (defmulti -generator (fn [[op] opts] op))
 
 (defmethod -generator :cat [[_ & rs] opts]
@@ -35,9 +34,6 @@
        :else       (assert false s))
      :cljs
      (.charCodeAt s 0)))
-
-(defmethod -generator :range [[_ from to] opts]
-  (gen/fmap char (gen/choose (char-code from) (char-code to))))
 
 (defmethod -generator :class [[_ & cs] opts]
   (gen/one-of (for [c cs]
@@ -127,7 +123,7 @@
                  [:class [\a \z] [\A \Z] [\0 \9] \_ \-]
                  "@"
                  [:capture
-                  [:repeat [:range \0 \9] 3 5]
+                  [:repeat [:class [\0 \9]] 3 5]
                   [:* [:not \.]]
                   "."
                   [:alt "com" "org" "net"]]

--- a/src/lambdaisland/regal/parse.cljc
+++ b/src/lambdaisland/regal/parse.cljc
@@ -1,0 +1,50 @@
+(ns lambdaisland.regal.parse
+  (:require [instaparse.core :as instaparse]
+            #?(:clj [clojure.java.io :as io]))
+  #?(:cljs
+     (:require-macros [lambdaisland.regal.parse :refer [inline-resource]])))
+
+#?(:clj
+   (defmacro inline-resource [path]
+     (slurp (io/resource path))))
+
+(def grammar
+  #?(:clj (io/resource "lambdaisland/regal/regex.bnf")
+     :cljs (inline-resource "lambdaisland/regal/regex.bnf")))
+
+(def parser (delay (instaparse/parser grammar)))
+
+(defn ^:private remove-QE
+  "Preprocesses a regex string (the same way that openjdk does) by
+  transforming all \\Q...\\E expressions. Returns a string which is
+  an equivalent regex that contains no \\Q...\\E expressions."
+  [^String s]
+  (if (.contains s "\\Q")
+    (letfn [(remove-QE-not-quoting [chars]
+              (lazy-seq
+               (when-let [[c1 & [c2 :as cs]] (seq chars)]
+                 (if (= \\ c1)
+                   (if (= \Q c2)
+                     (remove-QE-quoting-init (rest cs))
+                     (list* c1 c2 (remove-QE-not-quoting (rest cs))))
+                   (cons c1 (remove-QE-not-quoting cs))))))
+            ;; I don't understand why this clause in the java code,
+            ;; but it is, and this is what it does, and it has some
+            ;; weird effects, like in #"\c\Q0"
+            (remove-QE-quoting-init [chars]
+              (when-let [[c1 :as cs] (seq chars)]
+                (if (#{\0 \1 \2 \3 \4 \5 \6 \7 \8 \9} c1)
+                  (list* \\ \x \3 c1
+                         (remove-QE-quoting (rest cs)))
+                  (remove-QE-quoting cs))))
+            (remove-QE-quoting [chars]
+              (lazy-seq
+               (when-let [[c1 & [c2 :as cs]] (seq chars)]
+                 (if (and (= c1 \\) (= c2 \E))
+                   (remove-QE-not-quoting (rest cs))
+                   (if (or (re-matches #"[0-9a-zA-Z]" (str c1))
+                           (<= 128 (int c1) ))
+                     (cons c1 (remove-QE-quoting cs))
+                     (list* \\ c1 (remove-QE-quoting cs)))))))]
+      (apply str (remove-QE-not-quoting s)))
+    s))

--- a/src/lambdaisland/regal/spec_alpha.clj
+++ b/src/lambdaisland/regal/spec_alpha.clj
@@ -1,5 +1,6 @@
 (ns lambdaisland.regal.spec-alpha
   (:require [lambdaisland.regal :as regal]
+            [lambdaisland.regal.generator :as generator]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]))
 
@@ -76,3 +77,15 @@
 
 (defmethod op :not [_]
   (op-spec ::regal/class))
+
+(defn- resolver [kw]
+  (-> kw s/spec meta ::form))
+
+(defn spec [regal]
+  (let [opts    {:resolver resolver}
+        pattern (regal/regex regal opts)]
+    (with-meta
+      (s/with-gen
+        (partial re-find pattern)
+        #(generator/gen regal opts))
+      {::form regal})))

--- a/test/lambdaisland/regal/spec_gen_test.clj
+++ b/test/lambdaisland/regal/spec_gen_test.clj
@@ -1,0 +1,23 @@
+(ns lambdaisland.regal.spec-gen-test
+  (:require [lambdaisland.regal.spec-alpha]
+            [lambdaisland.regal :as regal]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as spec-gen]))
+
+(comment
+  (defspec generated-forms-can-be-converted
+    (prop/for-all [regal (s/gen ::regal/form)]
+      ;; test that generators generate valid regexes
+      (try
+        (prn regal)
+        (regal/regex regal)
+        (catch Exception _
+          false))))
+
+  (test #'generated-forms-can-be-converted)
+
+  ;; overflows easily
+  (binding [s/*recursion-limit* 3] (gen/generate (s/gen ::regal/form))))

--- a/test/lambdaisland/regal_test.cljc
+++ b/test/lambdaisland/regal_test.cljc
@@ -47,9 +47,6 @@
             :cljs "a?")
          (reg-str (regal/regex [:? "a"]))))
 
-  (is (= "[a-z]"
-         (reg-str (regal/regex [:range \a \z]))))
-
   (is (= "[a-z0-9_-]"
          (reg-str (regal/regex [:class [\a \z] [\0 \9] \_ \-]))))
 


### PR DESCRIPTION
Regal is all about the generators, the specs, the property based testing. As
such we want to have specs and generators, for regal expressions themselves, and
for the regular expressions/strings they describe, and be able to round trip
between regex patterns and regal expressions.

Basic use:
- [x] regal -> regex
- [x] regal -> generator

Spec use:
- [x] validate regal with spec
- [x] validate strings with regal specs
- [x] generate strings with regal specs

Meta:
- [ ] parse regex to regal
- [ ] generate valid regal expressions

Because we want regal <-> regex round tripping it's also important that we start
thinking about canonical representation. Ideally each regal expressions
corresponds with exactly one regex pattern, and vice versa. To that end I
removed `[:range ...]` for now, since it's just a convenience alias over
`[:class [...]]`.

I made some first steps towards parsing based on the work that Gary Fredericks has done in test.chuck using instaparse, then decided that I really wanted the generator first to be able to generate input for the parser.

This led me to tightening up the specs, making sure they don't create invalid regexes like `#"[^]"` or `#"?"`, but the generators for ::regal/form have a tendency to overflow the stack, so that's not great... Might need to ask around for help on that one.