### PR TITLE
Updatd malli integration to work with recent versions of malli. Some …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 ## Fixed
+- regal/malli integration didn't work with recent versions of Malli due to breaking changes in the malli API.   
 
 ## Changed
 

--- a/deps.edn
+++ b/deps.edn
@@ -23,9 +23,7 @@
   {:extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}
 
   :malli
-  {:extra-deps {metosin/malli {:mvn/version "0.0.1-SNAPSHOT"}
-                #_{:git/url "https://github.com/metosin/malli"
-                   :sha     "40ad376abe6d8edd25e52156e38f5ddfd3103a75"}}}
+  {:extra-deps {metosin/malli {:mvn/version "0.5.1"}}}
 
   :cljs
   {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.773"}}}

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -3,45 +3,51 @@
             [lambdaisland.regal.generator :as generator]
             [malli.core :as m]
             [malli.generator :as mg]
-            [malli.error :as me]))
+            [malli.error :as me]
+            [malli.impl.util :as miu]))
 
 (def regal-schema
   ^{:type ::into-schema}
   (reify m/IntoSchema
-    (-into-schema [_ properties [regal :as children] options]
+    (-type [_] :regal)
+    (-type-properties [_])
+    (-properties-schema [_ _])
+    (-children-schema [_ _])
+    (-into-schema [parent properties [regal :as children] options]
       (m/-check-children! :regal properties children {:min 1, :max 1})
-      (let [form (m/create-form :regal properties children)
+      (let [form (m/-create-form :regal properties children)
             regex (regal/regex regal)]
         ^{:type ::schema}
         (reify
           m/Schema
-          (-type [_] :regal)
           (-validator [_]
             (fn [x] (try (boolean (re-find regex x)) (catch #?(:clj Exception, :cljs js/Error) _ false))))
           (-explainer [this path]
             (fn [x in acc]
               (try
                 (if-not (re-find regex x)
-                  (conj acc (m/error path in this x))
+                  (conj acc (miu/-error path in this x))
                   acc)
                 (catch #?(:clj Exception, :cljs js/Error) e
-                  (conj acc (m/error path in this x (:type (ex-data e))))))))
+                  (conj acc (miu/-error path in this x (:type (ex-data e))))))))
           (-transformer [this transformer method options]
             (m/-value-transformer transformer this method options))
+          (-parser [_])
+          (-unparser [_])
           (-walk [this walker in options]
             (when (m/-accept walker this in options)
               (m/-outer walker this (vec children) in options)))
-          (-properties [_] properties)
+          (-properties [_] (merge {:error/message {:en "Pattern does not match"}} properties))
           (-options [_] options)
           (-children [_] children)
           (-form [_] form)
-
+          (-parent [_] parent)
           mg/Generator
           (-generator [this options]
             (generator/gen regal))
 
-          me/SchemaError
-          (-error [this]
+          #_me/SchemaError
+          #_(-error [this]
             {:error/message {:en "Pattern does not match"}}))))))
 
 (comment

--- a/test/lambdaisland/regal/malli_test.cljc
+++ b/test/lambdaisland/regal/malli_test.cljc
@@ -1,0 +1,19 @@
+(ns lambdaisland.regal.malli-test
+  (:require [clojure.test :refer [deftest  is ]]
+            [malli.core :as m]
+            [malli.error :as me]
+            [lambdaisland.regal.malli :as regal-malli]))
+
+(def malli-opts {:registry {:regal regal-malli/regal-schema}})
+
+(def form [:+ "y"])
+
+(def schema (m/schema [:regal form] malli-opts))
+
+(deftest regal-malli-test
+  (is (= [:regal [:+ "y"]] (m/form schema)))
+  (is (= :regal (m/type schema)))
+  (is (= true (m/validate schema "yyy")))
+  (is (= ["Pattern does not match"] (me/humanize (m/explain schema "xxx")))))
+
+

--- a/tests.edn
+++ b/tests.edn
@@ -5,4 +5,5 @@
 
  :tests [{:id :clj}
          {:id :cljs
-          :type :kaocha.type/cljs}]}
+          :type :kaocha.type/cljs
+          :cljs/timeout 20000}]}


### PR DESCRIPTION
…refactoring of core protocols broke the regal.malli schema impl.

Hi, I've made this change, and just added a quick unit test based on the existing inline comments.    I am however running into a bizarre issue with Kaocha.  After adding the malli-test ns, I get this when running from the command-line

```
...
WARNING: When invoking clojure.main, use -M
WARNING: No tests were found, make sure :test-paths and :ns-patterns are configured correctly in tests.edn.
```

I presumed it was an issue with the test class, but I've  manually run `run-tests ..` in CLJ and CLJS repls with no problem. run clj-kondo, etc. and nothing obvious seems to be wrong 


