### PR TITLE
Fix an issue with how the :any generator generates values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Added
 
+- `lambdaisland.regal.generator/sample` and
+  `lambdaisland.regal.generator/generate` now can take an optional size and (for
+  `generate`) seed
+
 ## Fixed
-- regal/malli integration didn't work with recent versions of Malli due to breaking changes in the malli API.   
+
+- regal/malli integration didn't work with recent versions of Malli due to breaking changes in the malli API.
+- Make sure the `:any` generator does not generate `\return` or `\newline`
 
 ## Changed
 

--- a/src/lambdaisland/regal/generator.cljc
+++ b/src/lambdaisland/regal/generator.cljc
@@ -63,7 +63,7 @@
   (platform/hex->int (subs h 2)))
 
 (def any-gen
-  (gen/such-that (complement #{\r \n \u0085 "\r" "\n" "\u0085"}) gen/char))
+  (gen/such-that (complement #{\return \newline \u0085 "\r" "\n" "\u0085"}) gen/char))
 
 (def whitespace-gen
   (gen/fmap (comp char parse-hex) (gen/one-of (map gen/return regal/whitespace-chars))))
@@ -265,11 +265,19 @@
                                               ::initial? true
                                               ::final? true)))))
 
-(defn sample [r]
-  (gen/sample (gen r)))
+(defn sample
+  ([r]
+   (gen/sample (gen r)))
+  ([r num-samples]
+   (gen/sample (gen r) num-samples)))
 
-(defn generate [r]
-  (gen/generate (gen r)))
+(defn generate
+  ([r]
+   (gen/generate (gen r)))
+  ([r size]
+   (gen/generate (gen r) size))
+  ([r size seed]
+   (gen/generate (gen r) size seed)))
 
 (comment
   (sample [:cat :digit :whitespace :word])


### PR DESCRIPTION
It should not generate newlines or carriage returns, instead it was not
generating the characters "r" and "n".

Fixes #28 

See https://www.youtube.com/watch?v=SF0zfVYf4dE

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
