### PR TITLE
Fix paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.2
+  clojure: lambdaisland/clojure@0.0.6
 
 commands:
   checkout_and_run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.6
+  clojure: lambdaisland/clojure@0.0.2
 
 commands:
   checkout_and_run:
@@ -11,19 +11,28 @@ commands:
         type: string
     steps:
       - checkout
+      - run: npm install ws
       - clojure/with_cache:
           cache_version: << parameters.clojure_version >>
           steps:
-            - run: npm install ws
             - kaocha/execute:
                 args: "--reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
+                aliases: ":dev:test:test-check:cljs:instaparse:malli"
       - kaocha/upload_codecov
 
 jobs:
+  java-15-clojure-1_10:
+    executor: clojure/openjdk15
+    steps: [{checkout_and_run: {clojure_version: "1.10.2"}}]
+
+  java-15-clojure-1_9:
+    executor: clojure/openjdk15
+    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
+    
   java-11-clojure-1_10:
     executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.2"}}]
 
   java-11-clojure-1_9:
     executor: clojure/openjdk11
@@ -31,7 +40,7 @@ jobs:
 
   java-9-clojure-1_10:
     executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.2"}}]
 
   java-9-clojure-1_9:
     executor: clojure/openjdk9
@@ -39,7 +48,7 @@ jobs:
 
   java-8-clojure-1_10:
     executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.2"}}]
 
   java-8-clojure-1_9:
     executor: clojure/openjdk8
@@ -48,9 +57,11 @@ jobs:
 workflows:
   kaocha_test:
     jobs:
+      - java-15-clojure-1_10
+      - java-15-clojure-1_9
       - java-11-clojure-1_10
-      #- java-11-clojure-1_9
+      - java-11-clojure-1_9
       - java-9-clojure-1_10
-      #- java-9-clojure-1_9
+      - java-9-clojure-1_9
       - java-8-clojure-1_10
-      #- java-8-clojure-1_9
+      - java-8-clojure-1_9

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "test" "resources"]
+{:paths ["src" "resources"]
  :deps  {}
 
  :aliases
@@ -7,14 +7,14 @@
 
   :spec-alpha
   {:extra-deps {org.clojure/spec.alpha {:mvn/version "0.2.187"}
-                expound                {:mvn/version "0.8.5"}}}
+                expound/expound                {:mvn/version "0.8.5"}}}
 
   :spec-alpha2
   {:extra-deps {org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
                                          :sha     "2f84e3a37cab76d44c58785ff4481597429bc1d3"}}}
 
   :instaparse
-  {:extra-deps {instaparse          {:mvn/version "1.4.10" }}}
+  {:extra-deps {instaparse/instaparse          {:mvn/version "1.4.10" }}}
 
   :test-check
   {:extra-deps {org.clojure/test.check {:mvn/version "1.1.0"}}}
@@ -35,12 +35,13 @@
                                       :sha            "a164d8ba32f48a632a3f285f41a52f93d7bd024d"}}}
 
   :test
-  {:extra-deps {lambdaisland/kaocha      {:mvn/version "RELEASE"}
+  {:extra-paths ["test"]
+   :extra-deps {lambdaisland/kaocha      {:mvn/version "RELEASE"}
                 lambdaisland/kaocha-cljs {:mvn/version "RELEASE"}
                 org.clojure/clojurescript {:mvn/version "1.10.773"}
                 org.clojure/spec.alpha {:mvn/version "0.2.187"}
-                expound                {:mvn/version "0.8.5"}
-                instaparse          {:mvn/version "1.4.10" }
+                expound/expound                {:mvn/version "0.8.5"}
+                instaparse/instaparse          {:mvn/version "1.4.10" }
                 org.clojure/test.check {:mvn/version "1.1.0"}
                 com.gfredericks/test.chuck {:mvn/version "0.2.10"}
                 metosin/malli {:mvn/version "0.5.1"}


### PR DESCRIPTION
Fix #21 as it suggests (i.e., moving tests from `:paths` to `extra-paths` in the `:test` alias). I also added namespaces to the dependencies to silence some warnings.