### PR TITLE
Specify a garbage collector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
           steps:
             - kaocha/execute:
                 args: "--reporter documentation --plugin cloverage --codecov"
+                clojure-args: "-J-XX:+UseG1GC"
                 clojure_version: << parameters.clojure_version >>
                 aliases: ":dev:test:test-check:cljs:instaparse:malli"
       - kaocha/upload_codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.1
+  kaocha: lambdaisland/kaocha@0.0.2
   clojure: lambdaisland/clojure@0.0.6
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
           steps:
             - kaocha/execute:
                 args: "--reporter documentation --plugin cloverage --codecov"
-                clojure-args: "-J-XX:+UseG1GC"
+                clojure-args: "-J-XX:+UseSerialGC"
                 clojure_version: << parameters.clojure_version >>
                 aliases: ":dev:test:test-check:cljs:instaparse:malli"
       - kaocha/upload_codecov

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -4,4 +4,4 @@ set -e
 
 [[ -d node_modules ]] || npm install ws
 
-clojure -J-XX:+UseG1GC -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"
+clojure -J-XX:+UseSerialGC -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -4,4 +4,4 @@ set -e
 
 [[ -d node_modules ]] || npm install ws
 
-clojure -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"
+clojure -J-XX:+UseG1GC -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -4,4 +4,4 @@ set -e
 
 [[ -d node_modules ]] || npm install ws
 
-clojure -J-XX:+UseSerialGC -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"
+clojure -J-XX:+UseParallelGC -A:dev:test:test-check:cljs:instaparse -m kaocha.runner "$@"


### PR DESCRIPTION
I'm wondering if the G1GC garbage collector avoids too much garbage accumulation, which is why tests run on later Java versions avoid getting the kill signal as much.

This theory is imperfect, as Java 9 was the first to enable it, yet those jobs frequently fail. My explanation for that is that maybe some of our CI hardware gets the older GC on Java 9.
