### PR TITLE
Alysbrooks specify gc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
           steps:
             - kaocha/execute:
                 args: "--reporter documentation --plugin cloverage --codecov"
+                clojure-args: "-J-XX:+UseG1GC"
                 clojure_version: << parameters.clojure_version >>
                 aliases: ":dev:test:test-check:cljs:instaparse:malli"
       - kaocha/upload_codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.1
+  kaocha: lambdaisland/kaocha@0.0.2
   clojure: lambdaisland/clojure@0.0.6
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
           steps:
             - kaocha/execute:
                 args: "--reporter documentation --plugin cloverage --codecov"
-                clojure-args: "-J-XX:+UseG1GC"
+                clojure-args: "-J-XX:+UseSerialGC"
                 clojure_version: << parameters.clojure_version >>
                 aliases: ":dev:test:test-check:cljs:instaparse:malli"
       - kaocha/upload_codecov


### PR DESCRIPTION
I tried a few GCs because the default GCs change from version to version, so it could explain why Java 9 jobs apparently fail due to lack of memory, but other versions don't.
    
I wondered if the G1GC garbage collector avoids too much garbage accumulation, which is why tests run on later Java versions avoid getting the kill signal as much. This theory is imperfect, as Java 9 was the first to enable it, yet those jobs frequently fail. My explanation for that is that maybe some of our CI hardware gets the older GC on Java 9. This doesn't seem to be the case.

The opposite could be the case, too, if Java 9 enabled G1GC on some hardware versions that later JVMs scaled back. If Java 8 fails, that would be evidence in favor of G1GC being the culprit. One of the Java 8 test runs failed with G1GC, but the other didn't. 