### PR TITLE
Alys/increase tests

### DIFF
--- a/test/lambdaisland/regal/re2_test.clj
+++ b/test/lambdaisland/regal/re2_test.clj
@@ -37,6 +37,8 @@
                     :let [java-result
                           (try (re-find (regal/regex regal) s)
                                (catch Exception _
+                                 :fai)
+                               (catch StackOverflowError _
                                  :fail))]
                     :when (not= :fail java-result)]
                    (is (= java-result

--- a/test/lambdaisland/regal/re2_test.clj
+++ b/test/lambdaisland/regal/re2_test.clj
@@ -28,7 +28,7 @@
     (catch Exception _
       false)))
 
-(defspec re2-matches-like-java 10
+(defspec re2-matches-like-java 100
   (with-redefs [regal-spec/token-gen #(s/gen (disj regal-spec/known-tokens :line-break :start :end))]
     (prop'/for-all [regal (s/gen ::regal/form)
                     :when (can-generate? regal)


### PR DESCRIPTION
Increasing the test-suite find some errors we didn't already, so the threshold should be raised, at least sometimes.

I still need to decide whether to fix the failing tests or to.

I might also revise the tests a bit—I think we can use `gen/such-that` instead of `for-all`, `:let`, and `:when`.