### PR TITLE
Update "Use with Malli" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ mapping namespaced keywords to Regal expressions.
 (require '[malli.core :as m]
          '[malli.error :as me]
          '[malli.generator :as mg]
-         '[lambdaisland.regal :as regal])
+         '[lambdaisland.regal :as regal]
+         '[lambdaisland.regal.generator :as regal-gen])
 
 (def form [:+ "y"])
 
@@ -296,6 +297,10 @@ mapping namespaced keywords to Regal expressions.
 
 (me/humanize (m/explain schema "xxx") {:errors {:re {:error/message {:en "Pattern does not match"}}}})
 ;; => ["Pattern does not match"]
+
+(mg/sample [:re {:gen/gen (regal-gen/gen form)} (regal/regex form)])
+;; => ("y" "y" "y" "y" "yy" "yy" "yyyyy" "yyyyy" "yyyyy" "yyyy")
+
 ```
 
 ### BYO test.check / spec-alpha

--- a/README.md
+++ b/README.md
@@ -276,31 +276,26 @@ mapping namespaced keywords to Regal expressions.
 (require '[malli.core :as m]
          '[malli.error :as me]
          '[malli.generator :as mg]
-         '[lambdaisland.regal.malli :as regal-malli])
-
-(def malli-opts {:registry {:regal regal-malli/regal-schema}})
+         '[lambdaisland.regal :as regal])
 
 (def form [:+ "y"])
 
-(def schema (m/schema [:regal form] malli-opts))
+(def schema [:re (regal/regex form)])
 
 (m/form schema)
-;; => [:regal [:+ "y"]]
+;; => [:re #"y+"]
 
 (m/type schema)
-;; => :regal
+;; => :re
 
 (m/validate schema "yyy")
 ;; => true
 
 (me/humanize (m/explain schema "xxx"))
-;; => ["unknown error"]
+;; => ["should match regex"]
 
-(me/humanize (m/explain schema "xxx") {:errors {:regal {:error/message {:en "Pattern does not match"}}}})
+(me/humanize (m/explain schema "xxx") {:errors {:re {:error/message {:en "Pattern does not match"}}}})
 ;; => ["Pattern does not match"]
-
-(mg/sample schema)
-;; => ("y" "yy" "yy" "yyyy" "yyyy" "y" "yyy" "yyyyy" "yyyyyyyyy" "yyyyyyyy")
 ```
 
 ### BYO test.check / spec-alpha


### PR DESCRIPTION
With the most recent versions of both libraries:
````clojure
lambdaisland/regal        {:mvn/version "0.0.143"}
metosin/malli             {:mvn/version "0.8.4"}
````

The examples from [Use with Malli](https://github.com/lambdaisland/regal#use-with-malli) README section do not work anymore:
```clojure
(require '[malli.core :as m]
         '[malli.error :as me]
         '[malli.generator :as mg]
         '[lambdaisland.regal.malli :as regal-malli])

(def malli-opts {:registry {:regal regal-malli/regal-schema}})

(def form [:+ "y"])

(def schema (m/schema [:regal form] malli-opts))
;; => Execution error (ArityException) at lambdaisland.regal.malli$reify__12770/_into_schema (malli.cljc:18).
;;    Wrong number of args (3) passed to: malli.core/-create-form
```

However, [malli now supports regex](https://github.com/metosin/malli#string-schemas) `:re` in default registry so you could use `regal` with `malli` like this:
````clojure
(require '[lambdaisland.regal :as regal]
         '[malli.core :as m])

(def schema [:re (regal/regex [:+ "y"])])
(m/validate schema "yyy")
;; => true
````

which looks simpler and more straightforward.

Regardless of whether or not `lambdaisland.regal.malli` namespace should be deprecated, I think it might be worth at least updating the readme so others trying to use those libraries together don't run into the same problem.

Let me know what you think and thank you for this library! 🙌 