### PR TITLE
Fix malli support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## Fixed
 * Support for latest Malli
+  * New schema type
+    * Deprecated `:regal` schema
+    * Prefer namespaced `::rm/regal` schema
+    * Please read docstrings in `lambdaisland.regal.malli`
+  * Breaking change: in order to avoid a runtime test.check dependency, generators have been moved.
+    * Call `(lambdaisland.regal.malli.generator/register-regal-generator)` to register a generator at testing time.
+      * Please read docstrings in `lambdaisland.regal.malli` for more information.
 
 ## Changed
 * Small additions and tweaks to documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 ## Fixed
+* Support for latest Malli
 
 ## Changed
 * Small additions and tweaks to documentation

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The `::rm/regal` schema provides a wrapper for regal checks.
          '[lambdaisland.regal.malli :as rm]
          '[lambdaisland.regal.malli.generator :as rmg])
 
-(def malli-opts {:registry {::rm/regal (rm/regal-schema)}})
+(def malli-opts {:registry {::rm/regal rm/rm-regal-schema}})
 
 (def schema (m/schema [::rm/regal [:+ "y"]] malli-opts))
 

--- a/README.md
+++ b/README.md
@@ -273,26 +273,24 @@ mapping namespaced keywords to Regal expressions.
 
 ### Use with Malli
 
-The `lambdaisland.regal.malli` namespace is no longer compatible with the latest
-Malli, so we don't offer a custom Regal Malli schema, but you can use Malli's
-regex schema instead (`:re`), passing it the results from Regal.
+The `::rm/regal` schema provides a wrapper for regal checks.
 
 ```clojure
 (require '[malli.core :as m]
          '[malli.error :as me]
          '[malli.generator :as mg]
-         '[lambdaisland.regal :as regal]
-         '[lambdaisland.regal.generator :as regal-gen])
+         '[lambdaisland.regal.malli :as rm]
+         '[lambdaisland.regal.malli.generator :as rmg])
 
-(def form [:+ "y"])
+(def malli-opts {:registry {::rm/regal (rm/regal-schema)}})
 
-(def schema [:re (regal/regex form)])
+(def schema (m/schema [::rm/regal [:+ "y"]] malli-opts))
 
 (m/form schema)
-;; => [:re #"y+"]
+;; => [::rm/regal [:+ "y"]]
 
 (m/type schema)
-;; => :re
+;; => ::rm/regal
 
 (m/validate schema "yyy")
 ;; => true
@@ -300,12 +298,9 @@ regex schema instead (`:re`), passing it the results from Regal.
 (me/humanize (m/explain schema "xxx"))
 ;; => ["should match regex"]
 
-(me/humanize (m/explain schema "xxx") {:errors {:re {:error/message {:en "Pattern does not match"}}}})
-;; => ["Pattern does not match"]
-
-(mg/sample [:re {:gen/gen (regal-gen/gen form)} (regal/regex form)])
+(rmg/register-regal-generator) ;; register generator for ::rm/regal schema
+(mg/sample schema)
 ;; => ("y" "y" "y" "y" "yy" "yy" "yyyyy" "yyyyy" "yyyyy" "yyyy")
-
 ```
 
 ### BYO test.check / spec-alpha

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -4,4 +4,4 @@ set -e
 
 [[ -d node_modules ]] || npm install ws
 
-clojure -A:dev:test -m kaocha.runner "$@"
+clojure -M:dev:test -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
   {:extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.13"}}}
 
   :malli
-  {:extra-deps {metosin/malli {:mvn/version "0.5.1"}}} ; pinning this for now, breaking changes
+  {:extra-deps {metosin/malli {:mvn/version "0.15.0"}}}
 
   :re2
   {:extra-deps {com.google.re2j/re2j {:mvn/version "1.7"}}}

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -30,7 +30,7 @@
          
          Add to registry with {:registry {:regal rm/regal-schema}}.
 
-         e.g., [regal [:+ \"y\"]]
+         e.g., [:regal [:+ \"y\"]]
 
          To register a generator, use (lambdaisland.regal.malli.generator/register-regal-generator {:type :regal})."
     :deprecated "0.0.144"

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -1,56 +1,33 @@
-(ns ^:deprecated lambdaisland.regal.malli
-  "Custom Malli schema that supports regal directly. No longer compatible with
-  latest Malli, see the README for an alternative way to combine the two."
+(ns lambdaisland.regal.malli
+  "Custom Malli schema that supports regal directly."
+  (:refer-clojure :exclude [type])
   (:require [lambdaisland.regal :as regal]
-            [lambdaisland.regal.generator :as generator]
             [malli.core :as m]
-            [malli.generator :as mg]
-            [malli.error :as me]
-            [malli.impl.util :as miu]))
+            [malli.util :as mu]))
 
-(def regal-schema
-  ^{:type ::into-schema}
-  (reify m/IntoSchema
-    (-type [_] :regal)
-    (-type-properties [_])
-    (-properties-schema [_ _])
-    (-children-schema [_ _])
-    (-into-schema [parent properties [regal :as children] options]
-      (m/-check-children! :regal properties children {:min 1, :max 1})
-      (let [form (m/-create-form :regal properties children)
-            regex (regal/regex regal)]
-        ^{:type ::schema}
-        (reify
-          m/Schema
-          (-validator [_]
-            (fn [x] (try (boolean (re-find regex x)) (catch #?(:clj Exception, :cljs js/Error) _ false))))
-          (-explainer [this path]
-            (fn [x in acc]
-              (try
-                (if-not (re-find regex x)
-                  (conj acc (miu/-error path in this x))
-                  acc)
-                (catch #?(:clj Exception, :cljs js/Error) e
-                  (conj acc (miu/-error path in this x (:type (ex-data e))))))))
-          (-transformer [this transformer method options]
-            (m/-value-transformer transformer this method options))
-          (-parser [_])
-          (-unparser [_])
-          (-walk [this walker in options]
-            (when (m/-accept walker this in options)
-              (m/-outer walker this (vec children) in options)))
-          (-properties [_] (merge {:error/message {:en "Pattern does not match"}} properties))
-          (-options [_] options)
-          (-children [_] children)
-          (-form [_] form)
-          (-parent [_] parent)
-          mg/Generator
-          (-generator [this options]
-            (generator/gen regal))
+(def default-regal-type
+  "The default m/type for regal-schema."
+  ::regal)
 
-          #_me/SchemaError
-          #_(-error [this]
-              {:error/message {:en "Pattern does not match"}}))))))
+(defn regal-schema
+  "Add to registry with {:registry {::rm/regal (rm/regal-schema)}}.
+
+  e.g., [::rm/regal [:+ \"y\"]]
+  
+  A custom m/type can be provided with the :type argument:
+    {:registry {:regal (rm/regal-schema {:type :regal)}}}
+  e.g., [:regal [:+ \"y\"]]"
+  ([] (regal-schema nil))
+  ([{:keys [type]
+     :or {type default-regal-type}}]
+   (mu/-util-schema
+     {:type type :min 1 :max 1
+      :childs 0 ;; no schema children
+      :fn (fn [_ [regal :as c] _]
+            (let [regex (regal/regex regal)]
+              [[regex] ;; children
+               c ;; forms
+               (m/schema [:re regex])]))})))
 
 (comment
   (require '[malli.core :as m]
@@ -58,17 +35,15 @@
            '[malli.generator :as mg]
            '[lambdaisland.regal.malli :as regal-malli])
 
-  (def malli-opts {:registry {:regal regal-malli/regal-schema}})
+  (def malli-opts {:registry {::regal (regal-malli/regal-schema)}})
 
-  (def form [:+ "y"])
-
-  (def schema (m/schema [:regal form] malli-opts))
+  (def schema (m/schema [::regal [:+ "y"]] malli-opts))
 
   (m/form schema)
-  ;; => [:regal [:+ "y"]]
+  ;; => [::regal [:+ "y"]]
 
   (m/type schema)
-  ;; => :regal
+  ;; => ::regal
 
   (m/validate schema "yyy")
   ;; => true

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -5,10 +5,6 @@
             [malli.core :as m]
             [malli.util :as mu]))
 
-(def default-regal-type
-  "The default m/type for regal-schema."
-  ::regal)
-
 (defn ->regal-schema
   "Add to registry with {:registry {::rm/regal (rm/->regal-schema)}}.
 
@@ -19,7 +15,7 @@
   e.g., [:regal [:+ \"y\"]]"
   ([] (->regal-schema nil))
   ([{:keys [type]
-     :or {type default-regal-type}}]
+     :or {type ::regal}}]
    (mu/-util-schema
      {:type type :min 1 :max 1
       :childs 0 ;; no schema children

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -9,15 +9,15 @@
   "The default m/type for regal-schema."
   ::regal)
 
-(defn regal-schema
-  "Add to registry with {:registry {::rm/regal (rm/regal-schema)}}.
+(defn ->regal-schema
+  "Add to registry with {:registry {::rm/regal (rm/->regal-schema)}}.
 
-  e.g., [::rm/regal [:+ \"y\"]]
+  e.g., [:rm/regal [:+ \"y\"]]
   
   A custom m/type can be provided with the :type argument:
     {:registry {:regal (rm/regal-schema {:type :regal)}}}
   e.g., [:regal [:+ \"y\"]]"
-  ([] (regal-schema nil))
+  ([] (->regal-schema nil))
   ([{:keys [type]
      :or {type default-regal-type}}]
    (mu/-util-schema
@@ -28,6 +28,26 @@
               [[regex] ;; children
                c ;; forms
                (m/schema [:re regex])]))})))
+
+(def
+  ^{:doc "Consider using rm-regal-schema as it is namespaced to avoid registry clashes.
+         
+         Add to registry with {:registry {:regal (rm/regal-schema)}}.
+
+         e.g., [regal [:+ \"y\"]]
+
+         To register a generator, use (lambdaisland.regal.malli.generator/register-regal-generator {:type :regal})."
+    :deprecated "0.0.144"
+    :superseded-by "rm-regal-schema"}
+  regal-schema (->regal-schema {:type :regal}))
+
+(def rm-regal-schema
+  "Add to registry with {:registry {::rm/regal rm-regal-schema}}.
+
+  e.g., [::rm/regal [:+ \"y\"]]
+  
+  To register a generator, use (lambdaisland.regal.malli.generator/register-regal-generator)."
+  (->regal-schema))
 
 (comment
   (require '[malli.core :as m]

--- a/src/lambdaisland/regal/malli.cljc
+++ b/src/lambdaisland/regal/malli.cljc
@@ -28,7 +28,7 @@
 (def
   ^{:doc "Consider using rm-regal-schema as it is namespaced to avoid registry clashes.
          
-         Add to registry with {:registry {:regal (rm/regal-schema)}}.
+         Add to registry with {:registry {:regal rm/regal-schema}}.
 
          e.g., [regal [:+ \"y\"]]
 

--- a/src/lambdaisland/regal/malli/generator.cljc
+++ b/src/lambdaisland/regal/malli/generator.cljc
@@ -1,0 +1,22 @@
+(ns lambdaisland.regal.malli.generator
+  (:require [lambdaisland.regal.generator :as generator]
+            [lambdaisland.regal.malli :as rm]
+            [malli.core :as m]
+            [malli.generator :as mg]))
+
+(defn regal-generator
+  "Returns a generator for a ::rm/regal schema."
+  [schema options]
+  (let [regal (second (m/form schema options))]
+    (generator/gen regal)))
+
+(defn register-regal-generator
+  "Registers generator for ::rm/regal schema.
+  
+  A custom m/type instead of ::rm/regal can be provided with the :type argument."
+  ([] (register-regal-generator nil))
+  ([{:keys [type]
+     :or {type rm/default-regal-type}}]
+   (defmethod mg/-schema-generator type
+     [schema options]
+     (regal-generator schema options))))

--- a/src/lambdaisland/regal/malli/generator.cljc
+++ b/src/lambdaisland/regal/malli/generator.cljc
@@ -1,6 +1,6 @@
 (ns lambdaisland.regal.malli.generator
   (:require [lambdaisland.regal.generator :as generator]
-            [lambdaisland.regal.malli :as rm]
+            [lambdaisland.regal.malli :as-alias rm]
             [malli.core :as m]
             [malli.generator :as mg]))
 
@@ -16,7 +16,7 @@
   A custom m/type instead of ::rm/regal can be provided with the :type argument."
   ([] (register-regal-generator nil))
   ([{:keys [type]
-     :or {type rm/default-regal-type}}]
+     :or {type ::rm/regal}}]
    (defmethod mg/-schema-generator type
      [schema options]
      (regal-generator schema options))))

--- a/test/lambdaisland/regal/malli/generator_test.cljc
+++ b/test/lambdaisland/regal/malli/generator_test.cljc
@@ -6,10 +6,18 @@
             [malli.error :as me]
             [malli.generator :as mg]))
 
+(rmg/register-regal-generator {:type :regal})
+
+(def deprecated-opts {:registry {:regal rm/regal-schema}})
+
+(deftest deprecated-regal-generator-test
+  (is (= ["y" "yy" "yyy" "yyy" "yy" "yyy" "yyyy" "yyy" "yyyy" "yyyyyy"]
+         (mg/sample [:regal [:+ "y"]] (assoc deprecated-opts :seed 0)))))
+
 (rmg/register-regal-generator)
 
-(def malli-opts {:registry {::rm/regal (rm/regal-schema)}})
+(def opts {:registry {::rm/regal rm/rm-regal-schema}})
 
 (deftest regal-generator-test
   (is (= ["y" "yy" "yyy" "yyy" "yy" "yyy" "yyyy" "yyy" "yyyy" "yyyyyy"]
-         (mg/sample [::rm/regal [:+ "y"]] (assoc malli-opts :seed 0)))))
+         (mg/sample [::rm/regal [:+ "y"]] (assoc opts :seed 0)))))

--- a/test/lambdaisland/regal/malli/generator_test.cljc
+++ b/test/lambdaisland/regal/malli/generator_test.cljc
@@ -1,0 +1,15 @@
+(ns lambdaisland.regal.malli.generator-test
+  (:require [clojure.test :refer [deftest  is ]]
+            [lambdaisland.regal.malli :as rm]
+            [lambdaisland.regal.malli.generator :as rmg]
+            [malli.core :as m]
+            [malli.error :as me]
+            [malli.generator :as mg]))
+
+(rmg/register-regal-generator)
+
+(def malli-opts {:registry {::rm/regal (rm/regal-schema)}})
+
+(deftest regal-generator-test
+  (is (= ["y" "yy" "yyy" "yyy" "yy" "yyy" "yyyy" "yyy" "yyyy" "yyyyyy"]
+         (mg/sample [::rm/regal [:+ "y"]] (assoc malli-opts :seed 0)))))

--- a/test/lambdaisland/regal/malli_test.cljc
+++ b/test/lambdaisland/regal/malli_test.cljc
@@ -4,9 +4,17 @@
             [malli.error :as me]
             [lambdaisland.regal.malli :as rm]))
 
-(def opts {:registry {::rm/regal (rm/regal-schema)}})
+(def deprecated-opts {:registry {:regal rm/regal-schema}})
 
-(deftest regal-malli-test
+(deftest deprecated-regal-malli-test
+  (is (= [:regal [:+ "y"]] (m/form [:regal [:+ "y"]] deprecated-opts)))
+  (is (= :regal (m/type [:regal [:+ "y"]] deprecated-opts)))
+  (is (= true (m/validate [:regal [:+ "y"]] "yyy" deprecated-opts)))
+  (is (= ["should match regex"] (me/humanize (m/explain [:regal [:+ "y"]] "xxx" deprecated-opts) deprecated-opts))))
+
+(def opts {:registry {::rm/regal rm/rm-regal-schema}})
+
+(deftest rm-regal-malli-test
   (is (= [::rm/regal [:+ "y"]] (m/form [::rm/regal [:+ "y"]] opts)))
   (is (= ::rm/regal (m/type [::rm/regal [:+ "y"]] opts)))
   (is (= true (m/validate [::rm/regal [:+ "y"]] "yyy" opts)))

--- a/test/lambdaisland/regal/malli_test.cljc
+++ b/test/lambdaisland/regal/malli_test.cljc
@@ -1,19 +1,13 @@
 (ns lambdaisland.regal.malli-test
-  (:require [clojure.test :refer [deftest  is ]]
+  (:require [clojure.test :refer [deftest is]]
             [malli.core :as m]
             [malli.error :as me]
-            [lambdaisland.regal.malli :as regal-malli]))
+            [lambdaisland.regal.malli :as rm]))
 
-(def malli-opts {:registry {:regal regal-malli/regal-schema}})
-
-(def form [:+ "y"])
-
-(def schema (m/schema [:regal form] malli-opts))
+(def opts {:registry {::rm/regal (rm/regal-schema)}})
 
 (deftest regal-malli-test
-  (is (= [:regal [:+ "y"]] (m/form schema)))
-  (is (= :regal (m/type schema)))
-  (is (= true (m/validate schema "yyy")))
-  (is (= ["Pattern does not match"] (me/humanize (m/explain schema "xxx")))))
-
-
+  (is (= [::rm/regal [:+ "y"]] (m/form [::rm/regal [:+ "y"]] opts)))
+  (is (= ::rm/regal (m/type [::rm/regal [:+ "y"]] opts)))
+  (is (= true (m/validate [::rm/regal [:+ "y"]] "yyy" opts)))
+  (is (= ["should match regex"] (me/humanize (m/explain [::rm/regal [:+ "y"]] "xxx" opts) opts))))


### PR DESCRIPTION
Malli now includes a utility to easily proxy an existing schema, so the regal schema is now a light wrapper of `:re`.

I propose we follow usual namespacing etiquette and call the schema `::rm/regal` instead of `:regal` by default, and expose enough configuration let users override it.